### PR TITLE
gemspec: Include fewer files, explicitly

### DIFF
--- a/i18n_utils.gemspec
+++ b/i18n_utils.gemspec
@@ -9,18 +9,18 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Henrik Nyh"]
   spec.email         = ["henrik@nyh.se"]
   spec.summary       = "I18n utilities for Ruby on Rails."
-  spec.homepage      = "http://github.com/henrik/i18n_utils"
+  spec.homepage      = "https://github.com/henrik/i18n_utils"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = Dir["lib/**/*"] + ["README.md", "LICENSE.txt"]
+  spec.executables   = []
+  spec.test_files    = Dir["spec/**/*"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "i18n"
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This PR is a cleanup and "make-more-explicit" change.

- No use of git shellout
- This gem exposes 0 executables.
- There's a single test directory, not changing often
- Unpin bundler dev dependency

<details>

```
➜  i18n_utils git:(master) bundle
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.3)

  Current Bundler version:
    bundler (2.2.13)

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:1.17.3` and rerun
bundler using `bundle _1.17.3_`

```

</details>