### PR TITLE
CI: Add Ruby 3.1 and test fix for Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby-version:
           - 3.1
-          - "3.0"
+          - 3.0
           - 2.7
           - 2.6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,16 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["3.0", "2.7", "2.6"]
+        ruby-version:
+          - 3.1
+          - "3.0"
+          - 2.7
+          - 2.6
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@ae9cb3b565e36682a2c6045e4f664388da4c73aa
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -45,7 +45,7 @@ describe I18nUtils do
       expect(self).to receive(:capture) { |&block| block.call }
 
       expect(self).to receive(:t).
-        with("sign_in_now.text", sign_in: %{<a href="url">Sign in</a>}).
+        with("sign_in_now.text", { sign_in: %{<a href="url">Sign in</a>}}).
         and_return("output")
 
       expect(self).to receive(:t).


### PR DESCRIPTION
This add Ruby 3.1, turns the Ruby versions list into a YAML  list which is perhaps easier to add/remove from. And, to have access to the Ruby 3.1 in setup-ruby, we use the v1-tagged version which gets updates.

In an second commit, a curious RSpec failure report was fixed, by adding explicit { and } to denote a hash value (as opposed to implicit keywoard arguments pre-3.0-style).